### PR TITLE
Add AWS EC2 Terraform example setup

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -1,0 +1,28 @@
+# AWS EC2
+
+This small setup can be used to provision Flatcar nodes on [AWS EC2](https://aws.amazon.com/ec2/).
+
+Create a `terraform.tfvars` file that lists your preferences. Like this one:
+
+```
+cluster_name            = "mycluster"
+machines                = ["mynode"]
+ssh_keys                = ["ssh-rsa AA... me@mail.net"]
+```
+
+The machine name listed in the `machines` variable is used to retrieve the corresponding [Container Linux Config](https://www.flatcar.org/docs/latest/provisioning/cl-config/). For each machine in the list, you should have a `machine-NAME.yaml.tmpl` file with a corresponding name. An example file `machine-mynode.yaml.tmpl` for `mynode` is already provided. The SSH key used there is not really necessary since we already set it as VM attribute.
+
+Now run Terraform (version 13) as follows:
+
+```
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+terraform init
+terraform apply
+```
+
+On the first run you will get an error with a URL where you have to confirm that you agree with the terms and conditions of the Marketplace image.
+
+When terraform is done running, it will print the IP addresses of the machines created. Log in via `ssh core@IPADDRESS` (maybe add `-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null`).
+
+When you make a change to `machine-mynode.yaml.tmpl` and run `terraform apply` again, the instance will be replaced. Consider using [`create_before_destroy`](https://www.terraform.io/docs/configuration/meta-arguments/lifecycle.html#syntax-and-arguments) in your final setup.

--- a/aws/aws-ec2-machines.tf
+++ b/aws/aws-ec2-machines.tf
@@ -1,0 +1,150 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    ct = {
+      source  = "poseidon/ct"
+      version = "0.7.1"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2.2.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0.0"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.19.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+resource "aws_vpc" "network" {
+  cidr_block = var.vpc_cidr
+
+  tags = {
+    Name = var.cluster_name
+  }
+}
+
+resource "aws_subnet" "subnet" {
+  vpc_id     = aws_vpc.network.id
+  cidr_block = var.subnet_cidr
+
+  tags = {
+    Name = var.cluster_name
+  }
+}
+
+resource "aws_internet_gateway" "gateway" {
+  vpc_id = aws_vpc.network.id
+
+  tags = {
+    Name = var.cluster_name
+  }
+}
+
+resource "aws_route_table" "default" {
+  vpc_id = aws_vpc.network.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.gateway.id
+  }
+
+  tags = {
+    Name = var.cluster_name
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  route_table_id = aws_route_table.default.id
+  subnet_id      = aws_subnet.subnet.id
+}
+
+resource "aws_security_group" "securitygroup" {
+  vpc_id = aws_vpc.network.id
+
+  tags = {
+    Name = var.cluster_name
+  }
+}
+
+resource "aws_security_group_rule" "outgoing_any" {
+  security_group_id = aws_security_group.securitygroup.id
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "incoming_any" {
+  security_group_id = aws_security_group.securitygroup.id
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_key_pair" "ssh" {
+  key_name   = var.cluster_name
+  public_key = var.ssh_keys.0
+}
+
+data "aws_ami" "flatcar_stable_latest" {
+  most_recent = true
+  owners      = ["aws-marketplace"]
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "name"
+    values = ["Flatcar-stable-*"]
+  }
+}
+
+resource "aws_instance" "machine" {
+  for_each      = toset(var.machines)
+  instance_type = var.instance_type
+  user_data     = data.ct_config.machine-ignitions[each.key].rendered
+  ami           = data.aws_ami.flatcar_stable_latest.image_id
+  key_name      = aws_key_pair.ssh.key_name
+
+  associate_public_ip_address = true
+  subnet_id                   = aws_subnet.subnet.id
+  vpc_security_group_ids      = [aws_security_group.securitygroup.id]
+
+  tags = {
+    Name = "${var.cluster_name}-${each.key}"
+  }
+}
+
+data "ct_config" "machine-ignitions" {
+  for_each = toset(var.machines)
+  content  = data.template_file.machine-configs[each.key].rendered
+}
+
+data "template_file" "machine-configs" {
+  for_each = toset(var.machines)
+  template = file("${path.module}/cl/machine-${each.key}.yaml.tmpl")
+
+  vars = {
+    ssh_keys = jsonencode(var.ssh_keys)
+    name     = each.key
+  }
+}

--- a/aws/cl/machine-mynode.yaml.tmpl
+++ b/aws/cl/machine-mynode.yaml.tmpl
@@ -1,0 +1,18 @@
+---
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys: ${ssh_keys}
+storage:
+  files:
+    - path: /home/core/works
+      filesystem: root
+      mode: 0755
+      contents:
+        inline: |
+          #!/bin/bash
+          set -euo pipefail
+          # This script demonstrates how templating and variable substitution works when using Terraform templates for Container Linux Configs.
+          hostname="$(hostname)"
+          echo My name is ${name} and the hostname is $${hostname}
+

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -1,0 +1,6 @@
+output "ip-addresses" {
+  value = {
+    for key in var.machines :
+    "${var.cluster_name}-${key}" => aws_instance.machine[key].public_ip
+  }
+}

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -1,0 +1,36 @@
+variable "machines" {
+  type        = list(string)
+  description = "Machine names, corresponding to cl/machine-NAME.yaml.tmpl files"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "Cluster name used as prefix for the machine names"
+}
+
+variable "ssh_keys" {
+  type        = list(string)
+  description = "SSH public keys for user 'core'"
+}
+
+variable "aws_region" {
+  type        = string
+  default     = "us-east-2"
+  description = "AWS Region to use for running the machine"
+}
+
+variable "instance_type" {
+  type        = string
+  default     = "t3.medium"
+  description = "Instance type for the machine"
+}
+
+variable "vpc_cidr" {
+  type    = string
+  default = "172.16.0.0/16"
+}
+
+variable "subnet_cidr" {
+  type    = string
+  default = "172.16.10.0/24"
+}

--- a/azure/README.md
+++ b/azure/README.md
@@ -17,7 +17,7 @@ You can resolve the latest Flatcar Stable version with this shell command:
 curl -sSfL https://stable.release.flatcar-linux.net/amd64-usr/current/version.txt | grep -m 1 FLATCAR_VERSION_ID= | cut -d = -f 2
 ```
 
-The machine name listed in the `machines` variable is used to retrieve the corresponding [Container Linux Config](https://kinvolk.io/docs/flatcar-container-linux/latest/container-linux-config-transpiler/configuration/). For each machine in the list, you should have a `machine-NAME.yaml.tmpl` file with a corresponding name. An example file `machine-mynode.yaml.tmpl` for `mynode` is already provided.
+The machine name listed in the `machines` variable is used to retrieve the corresponding [Container Linux Config](https://www.flatcar.org/docs/latest/provisioning/cl-config/). For each machine in the list, you should have a `machine-NAME.yaml.tmpl` file with a corresponding name. An example file `machine-mynode.yaml.tmpl` for `mynode` is already provided. The SSH key used there is not really necessary since we already set it as VM attribute.
 
 First find your subscription ID, then create a service account for Terraform and note the tenant ID, client (app) ID, client (password) secret:
 


### PR DESCRIPTION
The setup is the same as for the other clouds.


## How to use

see Readme

When merged also add it to the Flatcar AWS EC2 docs in a new Terraform section.

## Testing done

`terraform apply` and `ssh` to check that both SSH key sources get added under `authorized_keys.d/`