### PR TITLE
Restructure -without-instance-replacement variants to use flatcar-reset

### DIFF
--- a/azure-without-instance-replacement/.gitignore
+++ b/azure-without-instance-replacement/.gitignore
@@ -1,0 +1,3 @@
+vhs-demo.webm
+vhs-demo.mp4
+frames/

--- a/azure-without-instance-replacement/README.md
+++ b/azure-without-instance-replacement/README.md
@@ -1,10 +1,8 @@
 # Microsoft Azure without instance replacement
 
-This small setup can be used to provision Flatcar nodes on [Azure](https://azure.microsoft.com/) with the instance user data (Ignition config) of the node on Azure Blob Storage.
-It is an experiment to show how to circumvent instance replacement when updating the node user data by replacing just the Blob Storage contents and telling Ignition to rerun on the node.
-This only works when the Ignition config contains a directive to reformat the root filesystem, so that no old state is kept.
-The advantage is to be able to keep persistent data on another partition, keep the same IP address, and to reduce the time of re-applying a configuration change.
-Drawbacks are changing SSH host keys and a changing `/etc/machine-id` value, and due to a current limitation an additional reboot when provisioning the first time.
+This small setup can be used to provision Flatcar nodes on [Azure](https://azure.microsoft.com/) with the instance user data (Ignition config) used for reconfiguration. The advantage is to be able to keep persistent data, keep the same IP address, and to reduce the time of re-applying a configuration change.
+
+This setup uses the `flatcar-reset` tool to clean the rootfs while preserving allowed paths.
 
 Create a `terraform.tfvars` file that lists your preferences. Like this one:
 
@@ -12,22 +10,23 @@ Create a `terraform.tfvars` file that lists your preferences. Like this one:
 cluster_name            = "mycluster"
 machines                = ["mynode"]
 ssh_keys                = ["ssh-rsa AA... me@mail.net"]
-flatcar_stable_version  = "x.y.z"
+flatcar_alpha_version   = "x.y.z"
 ```
 
-You can resolve the latest Flatcar Stable version with this shell command:
+You can resolve the latest Flatcar Alpha version with this shell command:
 
 ```
-curl -sSfL https://stable.release.flatcar-linux.net/amd64-usr/current/version.txt | grep -m 1 FLATCAR_VERSION_ID= | cut -d = -f 2
+curl -sSfL https://alpha.release.flatcar-linux.net/amd64-usr/current/version.txt | grep -m 1 FLATCAR_VERSION_ID= | cut -d = -f 2
 ```
 
 The machine name listed in the `machines` variable is used to retrieve the corresponding [Container Linux Config](https://kinvolk.io/docs/flatcar-container-linux/latest/container-linux-config-transpiler/configuration/). For each machine in the list, you should have a `machine-NAME.yaml.tmpl` file with a corresponding name. An example file `machine-mynode.yaml.tmpl` for `mynode` is already provided.
 
-First find your subscription ID, then create a service account for Terraform and note the tenant ID, client (app) ID, client (password) secret:
+First find your subscription ID, then, if wanted, create a service account for Terraform and note the tenant ID, client (app) ID, client (password) secret:
 
 ```
 az login
 az account set --subscription <azure_subscription_id>
+# You can skip the creation of the service account if you rely on az login
 az ad sp create-for-rbac --name <service_principal_name> --role Contributor
 {
   "appId": "...",
@@ -42,20 +41,32 @@ AZ CLI installation docs are [here](https://docs.microsoft.com/en-us/cli/azure/i
 Before you run Terraform, accept the image terms:
 
 ```
-az vm image terms accept --urn kinvolk:flatcar-container-linux:stable:<flatcar_stable_version>
+az vm image terms accept --urn kinvolk:flatcar-container-linux:alpha:<flatcar_alpha_version>
 ```
 
 Now run Terraform (version 13) as follows:
 
 ```
 export ARM_SUBSCRIPTION_ID="<azure_subscription_id>"
-export ARM_TENANT_ID="<azure_subscription_tenant_id>"
-export ARM_CLIENT_ID="<service_principal_appid>"
-export ARM_CLIENT_SECRET="<service_principal_password>"
+export ARM_TENANT_ID="<azure_subscription_tenant_id>"  # skip if you used az login
+export ARM_CLIENT_ID="<service_principal_appid>"  # skip if you used az login
+export ARM_CLIENT_SECRET="<service_principal_password>"  # skip if you used az login
 terraform init
 terraform apply
 ```
 
-When terraform is done running, it will print the IP addresses of the machines created. Log in via `ssh core@IPADDRESS` (maybe add `-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null`).
+When terraform is done running, it will print the IP addresses of the machines created. Log in via `ssh core@IPADDRESS` (maybe add `-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o NumberOfPasswordPrompts=0`).
 
-When you make a change to `machine-mynode.yaml.tmpl` and run `terraform apply` again, the instance is just rebooted and the new config applied.
+When you make a change to `machine-mynode.yaml.tmpl` (e.g., `my-setting v1` to `my-setting v2` and run `terraform apply` again, the instance is just rebooted instead of recreated and the new Ignition config applied while keeping wanted data (see `KEEPPATHS` setting) and discarding the rest.
+
+We can run this command to compare the values of `/etc/config-side-effect` and `/mydata/data` before and after the run. We should see that `/etc/config-side-effect` changes while `/mydata/data` stays the same.
+
+```
+az vm run-command invoke -g mycluster-rg -n mycluster-mynode --command-id RunShellScript --scripts "head /etc/config-side-effect /mydata/data" | jq -r '.value[0].message'
+# or
+ssh core@20.232.140.103 head /etc/config-side-effect /mydata/data
+```
+
+## Demo
+
+You can watch a recording of the `vhs-demo.tape` [here](https://www.youtube.com/watch?v=1_QcY1ic7mA).

--- a/azure-without-instance-replacement/cl/machine-mynode.yaml.tmpl
+++ b/azure-without-instance-replacement/cl/machine-mynode.yaml.tmpl
@@ -1,41 +1,43 @@
----
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/bin/test-service.sh
+      mode: 0755
+      contents:
+        inline: |
+          #!/bin/bash
+          set -euo pipefail
+          if test ! -e /etc/config-side-effect; then
+            echo "my-setting v1" > /etc/config-side-effect
+          fi
+          mkdir -p /mydata
+          if test ! -e /mydata/data; then
+            echo "$RANDOM" > /mydata/data
+          fi
+systemd:
+  units:
+    - name: test.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Test service with side-effect
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        Restart=on-failure
+        ExecStart=/opt/bin/test-service.sh
+        [Install]
+        WantedBy=multi-user.target
+    - name: sshd.socket
+      dropins:
+      - name: 10-sshd-port.conf
+        contents: |
+          [Socket]
+          ListenStream=
+          ListenStream=${port}
 passwd:
   users:
     - name: core
       ssh_authorized_keys: ${ssh_keys}
-storage:
-  files:
-    - path: /home/core/works
-      filesystem: root
-      mode: 0755
-      contents:
-        inline: |
-          #!/bin/bash
-          set -euo pipefail
-          # This script demonstrates how templating and variable substitution works when using Terraform templates for Container Linux Configs.
-          hostname="$(hostname)"
-          echo My name is ${name} and the hostname is $${hostname}
-    - path: /reprovision
-      filesystem: oem
-      mode: 0755
-      contents:
-        inline: |
-          #!/bin/bash
-          set -euo pipefail
-          touch /usr/share/oem/grub.cfg
-          sed -i "/linux_append ignition.config.url=.*/d" /usr/share/oem/grub.cfg
-          MI=$(cat /etc/machine-id)
-          echo "set linux_append=\"\$linux_append ignition.config.url=$1 systemd.machine_id=$${MI}\"" >> /usr/share/oem/grub.cfg
-          touch /boot/flatcar/first_boot
-  filesystems:
-    - name: root
-      mount:
-        device: /dev/disk/by-label/ROOT
-        format: ext4
-        wipe_filesystem: true
-        label: ROOT
-    - name: oem
-      mount:
-        device: /dev/disk/by-label/OEM
-        format: btrfs
-        label: OEM

--- a/azure-without-instance-replacement/reprovision-helper
+++ b/azure-without-instance-replacement/reprovision-helper
@@ -1,0 +1,56 @@
+#!/bin/sh
+# This script will be executed in-line (like sourcing, hence first line is ignored and it may not be bash)
+# It can also be used used stand-alone for testing if these env vars are declared:
+# MODE, NAME, RGROUP, PUBLICIP, PORT, EXPECTED, KEEPPATHS
+# Note that the script must not use the $VAR format for the above because Terraform only replaces in curly brackets
+# and on the other hand, $VAR should be used for all other variables
+set -eu
+
+echo "Preparing rg ${RGROUP} vm ${NAME} to keep ${KEEPPATHS}"
+
+run() {
+  cmd="$1"
+  if [ "${MODE}" = "ssh" ]; then
+    echo "Using SSH via ${PUBLICIP}:${PORT}"
+    while ! ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o NumberOfPasswordPrompts=0 -p "${PORT}" "core@${PUBLICIP}" "set -euo pipefail; $cmd"; do
+      sleep 1
+    done
+  else
+    # Workaround for az vm run-command invoke: Use END to signal execution without errors
+    RUN=$(az vm run-command invoke -g "${RGROUP}" -n "${NAME}" --command-id RunShellScript --scripts "set -euo pipefail; $cmd ; echo END")
+    if ! echo "$RUN" | grep -q END; then
+      exit 1
+    fi
+  fi
+}
+
+# Azure workaround to prevent a race with serving outdated userData (despite using depends_on = [azurerm_linux_virtual_machine.machine]),
+# making use of the fact that Terraform also runs this action directly after the fresh provisioning
+EXPECTEDSUM=$(echo "${EXPECTED}" | base64 -d | sha512sum)
+# Terraform workaround: Terraform also runs this script directly after the first provisioning, not only on changes,
+# we need to detect this on the instance to prevent an unnecessary reboot on first boot by managing /.reprovision-marker
+run "
+SUM=\$(curl -sSfL -H 'Metadata: true' 'http://169.254.169.254/metadata/instance/compute/userData?api-version=2021-01-01&format=text' | base64 -d | sha512sum)
+if test -e /.reprovision-marker ; then
+  while [ \"\$SUM\" != \"$EXPECTEDSUM\" ]; do
+    sleep 1
+    echo 'Waiting for metadata server to catch up'
+    SUM=\$(curl -sSfL -H 'Metadata: true' 'http://169.254.169.254/metadata/instance/compute/userData?api-version=2021-01-01&format=text' | base64 -d | sha512sum)
+  done
+  sudo flatcar-reset --keep-machine-id --keep-path '/.reprovision-marker' ${KEEPPATHS}
+  if [ \"${MODE}\" = \"ssh\" ]; then echo 'Rebooting now'; sudo systemctl reboot; else echo REBOOT; fi
+else
+  sudo touch /.reprovision-marker
+  echo 'First run, ignored'
+fi"
+
+if [ "${MODE}" != "ssh" ] && echo "$RUN" | grep -q REBOOT; then
+  echo "Ran flatcar-reset, will reboot"
+  az vm restart -g "${RGROUP}" -n "${NAME}"
+  echo "Reboot issued"
+fi
+
+# The reboot could also be done with the Kubernetes kured reboot manager by doing "sudo touch /run/reboot-required".
+# The running of flatcar-reset could also be done through a daemon that checks the metadata service for changes
+# with the main difference that changing the data retention setting would have to be part of Ignition itself and changes
+# for it won't apply for the issued reprovisioning but only future reprovisionings.

--- a/azure-without-instance-replacement/variables.tf
+++ b/azure-without-instance-replacement/variables.tf
@@ -1,6 +1,7 @@
 variable "resource_group_location" {
-  default     = "eastus"
+  type        = string
   description = "Location of the resource group."
+  default     = "eastus"
 }
 
 variable "machines" {
@@ -20,11 +21,23 @@ variable "ssh_keys" {
 
 variable "server_type" {
   type        = string
-  default     = "Standard_D2s_v4"
   description = "The server type to rent"
+  default     = "Standard_D2s_v4"
 }
 
-variable "flatcar_stable_version" {
+variable "flatcar_alpha_version" {
   type        = string
-  description = "The Flatcar Stable release you want to use for the initial installation, e.g., 2605.12.0"
+  description = "The Flatcar Alpha release you want to use for the initial installation, must be >= 3535.0.0"
+}
+
+variable "ssh_port" {
+  type        = string
+  description = "Custom SSH port"
+  default     = "22"
+}
+
+variable "mode" {
+  type        = string
+  description = "Reprovision mode (ssh or az)"
+  default     = "ssh"
 }

--- a/azure-without-instance-replacement/vhs-demo.tape
+++ b/azure-without-instance-replacement/vhs-demo.tape
@@ -1,0 +1,57 @@
+# Demo script, create the recording with 'vhs vhs-demo.tape'
+# after first provisioning manually with 'terraform0.13.5 init'
+# and 'terraform0.13.5 apply'.
+# For more, see https://github.com/charmbracelet/vhs
+Output vhs-demo.mp4
+# Prevent filling up /tmp
+Output frames/
+
+# You have to install these binaries/symlinks
+Require bat
+Require jq
+Require terraform0.13.5
+
+Set Shell "bash"
+Set FontSize 22
+Set Width 1920
+Set Height 1080
+Set Framerate 25
+Set TypingSpeed 120ms 
+
+# We could also spawn an asciinema shell here to get a text recording as well
+Type "# To save time, a server is already provisioned with 'terraform0.13.5 apply'" Sleep 500ms Enter
+Type "# It runs with the following Ignition configuration:" Sleep 500ms Enter
+Type "bat -P --line-range :32 cl/machine-mynode.yaml.tmpl" Sleep 1s Enter
+Sleep 15s
+Type "# For a reliable reconfiguration, /etc/config-side-effect should be cleaned up to get recreated by the service," Enter
+Type "# while /mydata/data should be kept." Sleep 1s Enter
+Type "# We will also preserve the SSH host keys and system logs on reconfigurations:" Sleep 500ms Enter
+Type "grep KEEPPATHS azure-vms.tf" Sleep 500ms Enter Sleep 5s Enter
+Type "# Each time Terraform sees a userdata change, it will run the following helper:" Sleep 750ms Enter
+Type "bat -P --line-range 27:45 reprovision-helper" Sleep 1s Enter
+Sleep 15s
+Type "# There are two workarounds, one for the Azure userdata endpoint, and an optimization for Terraform" Enter
+Type "# to prevent a direct reboot (/.reprovision-marker) after provisioning." Enter
+Type "# The essence is to run 'flatcar-reset --keep-machine-id --keep-path REGEX...' and then reboot." Sleep 3s Enter
+Type "# Let's prepare a configuration change that triggers the reprovisioning:" Sleep 3s Enter
+Type "nano cl/machine-mynode.yaml.tmpl" Sleep 3s Enter Sleep 2s Ctrl+W Sleep 300ms Type "v1" Enter Sleep 300ms Right 2 Backspace 1 Sleep 300ms Type "2" Sleep 1s Ctrl+S Sleep 300ms Ctrl+X Sleep 1s
+Type "git diff" Sleep 500ms Enter Sleep 3s
+Type "# Check the current values: " Enter
+Set TypingSpeed 30ms
+Type "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o NumberOfPasswordPrompts=0 -p $({ grep ssh_port terraform.tfvars || echo '=22' ; } | cut -s -d = -f 2 | jq -r) core@$(terraform0.13.5 output ip-addresses | cut -s -d = -f 2 | jq -r) head /etc/config-side-effect /mydata/data" Enter Sleep 5s
+Set TypingSpeed 120ms
+Type "terraform0.13.5 apply" Enter Sleep 60s
+Type "yes" Enter Sleep 30s
+Sleep 30s
+Type "# The instance will now reboot, then in the initramfs clean the rootfs except for what we want to keep (/mydata), finally run Ignition again and come up reconfigured" Sleep 500ms Enter
+Type "# Check the new values (setting should be v2, but data value should be as before)" Sleep 500ms Enter
+Set TypingSpeed 30ms
+Type "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o NumberOfPasswordPrompts=0 -p $({ grep ssh_port terraform.tfvars || echo '=22' ; } | cut -s -d = -f 2 | jq -r) core@$(terraform0.13.5 output ip-addresses | cut -s -d = -f 2 | jq -r) head /etc/config-side-effect /mydata/data" Enter Sleep 5s
+Set TypingSpeed 120ms
+Type "# That's the end of the demo" Enter
+Sleep 10s
+# Undo the done changes for later reruns
+Type "git checkout -- cl/machine-mynode.yaml.tmpl" Enter
+Type "terraform0.13.5 apply" Enter Sleep 60s
+Type "yes" Enter Sleep 30s
+Sleep 30s

--- a/equinix-metal-aka-packet-without-instance-replacement/cl/machine-mynode.yaml.tmpl
+++ b/equinix-metal-aka-packet-without-instance-replacement/cl/machine-mynode.yaml.tmpl
@@ -1,40 +1,36 @@
----
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/bin/test-service.sh
+      mode: 0755
+      contents:
+        inline: |
+          #!/bin/bash
+          set -euo pipefail
+          if test ! -e /etc/config-side-effect; then
+            echo "my-setting v1" > /etc/config-side-effect
+          fi
+          mkdir -p /mydata
+          if test ! -e /mydata/data; then
+            echo "$RANDOM" > /mydata/data
+          fi
+systemd:
+  units:
+    - name: test.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Test service with side-effect
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        Restart=on-failure
+        ExecStart=/opt/bin/test-service.sh
+        [Install]
+        WantedBy=multi-user.target
 passwd:
   users:
     - name: core
       ssh_authorized_keys: ${ssh_keys}
-storage:
-  files:
-    - path: /home/core/works
-      filesystem: root
-      mode: 0755
-      contents:
-        inline: |
-          #!/bin/bash
-          set -euo pipefail
-          hostname="$(hostname)"
-          echo My name is ${name} and the hostname is $${hostname}
-    - path: /reprovision
-      filesystem: oem
-      mode: 0755
-      contents:
-        inline: |
-          #!/bin/bash
-          set -euo pipefail
-          touch /usr/share/oem/grub.cfg
-          sed -i "/linux_append systemd.machine_id=.*/d" /usr/share/oem/grub.cfg
-          MI=$(cat /etc/machine-id)
-          echo "set linux_append=\"\$linux_append systemd.machine_id=$${MI}\"" >> /usr/share/oem/grub.cfg
-          touch /boot/flatcar/first_boot
-  filesystems:
-    - name: root
-      mount:
-        device: /dev/disk/by-label/ROOT
-        format: ext4
-        wipe_filesystem: true
-        label: ROOT
-    - name: oem
-      mount:
-        device: /dev/disk/by-label/OEM
-        format: btrfs
-        label: OEM

--- a/equinix-metal-aka-packet-without-instance-replacement/metal-machines.tf
+++ b/equinix-metal-aka-packet-without-instance-replacement/metal-machines.tf
@@ -2,12 +2,12 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     metal = {
-      source = "equinix/metal"
-      version = "3.3.0-alpha.1"
+      source  = "equinix/equinix"
+      version = "1.13.0"
     }
     ct = {
       source  = "poseidon/ct"
-      version = "0.7.1"
+      version = "0.11.0"
     }
     template = {
       source  = "hashicorp/template"
@@ -17,9 +17,8 @@ terraform {
       source  = "hashicorp/null"
       version = "~> 3.0.0"
     }
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.19.0"
+    equinix = {
+      source = "terraform-providers/equinix"
     }
   }
 }
@@ -27,45 +26,50 @@ terraform {
 resource "null_resource" "reboot-when-ignition-changes" {
   for_each = toset(var.machines)
   triggers = {
-    ignition_config = data.ct_config.machine-ignitions[each.key].rendered
+    ignition_config    = data.ct_config.machine-ignitions[each.key].rendered
+    reprovision_helper = data.template_file.reprovision[each.key].rendered
   }
   # Wait for the new Ignition config object to be ready before rebooting
-  depends_on = [aws_s3_bucket_object.object]
-  # Trigger running Ignition on the next reboot and reboot the instance (current limitation: also runs on the first provisioning)
+  depends_on = [equinix_metal_device.machine]
+  # Trigger running Ignition on the next reboot and reboot the instance
   provisioner "local-exec" {
-    command = "while ! ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null core@${metal_device.machine[each.key].access_public_ipv4} sudo /usr/share/oem/reprovision ; do sleep 1; done; while ! ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null core@${metal_device.machine[each.key].access_public_ipv4} sudo systemctl reboot; do sleep 1; done"
+    command = data.template_file.reprovision[each.key].rendered
   }
 }
 
-resource "metal_device" "machine" {
+data "template_file" "reprovision" {
+  for_each = toset(var.machines)
+  template = file("${path.module}/reprovision-helper")
+
+  vars = {
+    # Space separated list of regexes for data to keep when reconfiguring the instance with Ignition (quote with ' only, using " is not allowed)
+    KEEPPATHS = "'/etc/ssh/ssh_host_.*' /mydata /var/log"
+    PUBLICIP  = equinix_metal_device.machine[each.key].access_public_ipv4
+    NAME      = equinix_metal_device.machine[each.key].hostname
+  }
+}
+
+resource "equinix_metal_device" "machine" {
   for_each         = toset(var.machines)
   hostname         = "${var.cluster_name}-${each.key}"
   plan             = var.plan
   facilities       = var.facilities
-  operating_system = "flatcar_stable"
+  operating_system = "flatcar_alpha" # requires at least Alpha 3535.0.0
   billing_cycle    = "hourly"
   project_id       = var.project_id
-  # Workaround: Indirection through AWS S3 because "lifecycle { ignore_changes = [user_data] }" will not update the user data and leaving it out would replace the instance
-  user_data        = "{ \"ignition\": { \"version\": \"2.1.0\", \"config\": { \"replace\": { \"source\": \"s3://${aws_s3_bucket_object.object[each.key].bucket}/${aws_s3_bucket_object.object[each.key].id}\" } } } }"
-}
+  user_data        = data.ct_config.machine-ignitions[each.key].rendered
 
-resource "aws_s3_bucket" "user-data-forcenew-workaround" {
-  bucket = "user-data-forcenew-workaround-${var.cluster_name}"
-  acl    = "public-read"
-}
-
-# Ignition config, publicly accessible
-resource "aws_s3_bucket_object" "object" {
-  bucket   = aws_s3_bucket.user-data-forcenew-workaround.id
-  for_each = toset(var.machines)
-  key      = "${var.cluster_name}-${each.key}"
-  acl      = "public-read"
-  content  = data.ct_config.machine-ignitions[each.key].rendered
+  behavior {
+    allow_changes = [
+      "user_data"
+    ]
+  }
 }
 
 data "ct_config" "machine-ignitions" {
   for_each = toset(var.machines)
   content  = data.template_file.machine-configs[each.key].rendered
+  strict   = true
 }
 
 data "template_file" "machine-configs" {

--- a/equinix-metal-aka-packet-without-instance-replacement/outputs.tf
+++ b/equinix-metal-aka-packet-without-instance-replacement/outputs.tf
@@ -1,6 +1,6 @@
 output "ip-addresses" {
   value = {
     for key in var.machines :
-    "${var.cluster_name}-${key}" => metal_device.machine[key].access_public_ipv4
+    "${var.cluster_name}-${key}" => equinix_metal_device.machine[key].access_public_ipv4
   }
 }

--- a/equinix-metal-aka-packet-without-instance-replacement/reprovision-helper
+++ b/equinix-metal-aka-packet-without-instance-replacement/reprovision-helper
@@ -1,0 +1,35 @@
+#!/bin/sh
+# This script will be executed in-line (like sourcing, hence first line is ignored and it may not be bash)
+# It can also be used used stand-alone for testing if these env vars are declared:
+# NAME, PUBLICIP, KEEPPATHS
+# Note that the script must not use the $VAR format for the above because Terraform only replaces in curly brackets
+# and on the other hand, $VAR should be used for all other variables
+set -eu
+
+run() {
+  cmd="$1"
+  while ! ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o NumberOfPasswordPrompts=0 "core@${PUBLICIP}" "set -euo pipefail; $cmd"; do
+    sleep 1
+  done
+}
+
+
+# Equinix Metal workaround: First make sure that we run the latest Flatcar Alpha:
+run "if grep -q 3227.0.0 /etc/os-release; then sudo flatcar-update -V 3535.0.0 ; sudo systemctl reboot ; exit 1; fi"
+
+echo "Preparing device ${NAME} ${PUBLICIP} to keep ${KEEPPATHS}"
+
+# Terraform workaround: Terraform also runs this script directly after the first provisioning, not only on changes, we need to detect this through a /.reprovision-marker file on the instance to prevent an unnecessary reboot on first boot
+
+run "if test -e /.reprovision-marker; then
+  sudo flatcar-reset --keep-machine-id --keep-path '/.reprovision-marker' ${KEEPPATHS}
+  sudo systemctl reboot
+else
+  sudo touch /.reprovision-marker
+  echo 'First run, ignored'
+fi"
+
+# The reboot could also be done with the Kubernetes kured reboot manager by doing "sudo touch /run/reboot-required".
+# The running of flatcar-reset could also be done through a daemon that checks the metadata service for changes
+# with the main difference that changing the data retention setting would have to be part of Ignition itself and changes
+# for it won't apply for the issued reprovisioning but only future reprovisionings.

--- a/equinix-metal-aka-packet/metal-machines.tf
+++ b/equinix-metal-aka-packet/metal-machines.tf
@@ -7,7 +7,7 @@ terraform {
     }
     ct = {
       source  = "poseidon/ct"
-      version = "0.7.1"
+      version = "0.11.0"
     }
     template = {
       source  = "hashicorp/template"


### PR DESCRIPTION
With the selective OS reset provided by flatcar-reset in the latest Alpha, we can drop the Ignition rootfs reformat workaround. The terraform helper action for reprovisioning has been moved to a script file and can now detect the first run to skip it as this would mean to directly reprovision after provisioning (I see no good way to express this in Terraform itself). For Azure SSH (also on a custom port) or the az script command can be used for interaction. In the future one could also think about having a service on the instance that queries the userdata from the metadata API to detect changes. Since this setup is used for a presentation, a VHS demo tape is also brought in.

## How to use

Demo available in https://youtu.be/1_QcY1ic7mA

## Testing done

Recorded the scripted demo above and tested the az cli mode manually
