### PR TITLE
Bump hetznercloud/hcloud provider to v1.38.2 version

### DIFF
--- a/flatcar-terraform-hetzner/versions.tf
+++ b/flatcar-terraform-hetzner/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     hcloud = {
       source  = "hetznercloud/hcloud"
-      version = "1.36.0"
+      version = "1.38.2"
     }
     ct = {
       source  = "poseidon/ct"


### PR DESCRIPTION
# Bump hetznercloud/hcloud provider to v1.38.2 version

Running apply with the old provider throws the following error. Bumping to latest provider fixes the error

```
│ Error: more than one Image found for name debian-11
```
