### PR TITLE
openstack: add optional SSH security group

### DIFF
--- a/openstack/README.md
+++ b/openstack/README.md
@@ -67,6 +67,7 @@ The provisioning automation can be customised via settings in [`terraform.tfvars
     Read more about channels [here](https://www.flatcar.org/releases).
   - `flatcar_version`: Select the desired Flatcar version for the given channel (default to "current", which is the latest).
   - `flavor_name`: The spec of the machine, it default to ds1G (1vCPU, 10GB of disk and 1GB of memory)
+  - `ssh`: A boolean to create and attach a security group to the instances to allow SSH connections. (_NOTE_: At this moment, when creating an instance with this variable enabled then turning it off does not work as the security group is not firstly detached from the instance so the security group can't be deleted)
 
 [afterburn]: https://coreos.github.io/afterburn/
 [container-linux-config]: https://www.flatcar.org/docs/latest/provisioning/config-transpiler/configuration/

--- a/openstack/compute.tf
+++ b/openstack/compute.tf
@@ -46,6 +46,8 @@ resource "openstack_compute_instance_v2" "instance" {
   }
 
   user_data = data.ct_config.machine-ignitions[each.key].rendered
+
+  security_groups = flatten([["default"], var.ssh ? [openstack_networking_secgroup_v2.ssh[0].name] : []])
 }
 
 data "ct_config" "machine-ignitions" {

--- a/openstack/network.tf
+++ b/openstack/network.tf
@@ -1,0 +1,27 @@
+resource "openstack_networking_secgroup_v2" "ssh" {
+  name        = "ssh-terraform"
+  description = "Allow SSH from the outside - Managed by Terraform"
+  count       = var.ssh ? 1 : 0
+}
+
+resource "openstack_networking_secgroup_rule_v2" "ssh-ipv4" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.ssh[0].id
+  count             = var.ssh ? 1 : 0
+}
+
+resource "openstack_networking_secgroup_rule_v2" "ssh-ipv6" {
+  direction         = "ingress"
+  ethertype         = "IPv6"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = "::/0"
+  security_group_id = openstack_networking_secgroup_v2.ssh[0].id
+  count             = var.ssh ? 1 : 0
+}

--- a/openstack/variables.tf
+++ b/openstack/variables.tf
@@ -64,3 +64,9 @@ variable "region" {
   description = "OpenStack region"
   default     = "RegionOne"
 }
+
+variable "ssh" {
+  type        = bool
+  description = "Allow SSH connection from the outside"
+  default     = false
+}


### PR DESCRIPTION
Noticed this week-end that the default setup does not allow SSH connections. Added an optional resource to configure the SSH security group.

_NOTE_: Creating an instance with SSH security group _then_ turning off the `ssh` boolean does not work as the security group is not firstly detached from the instance so the security group can't be deleted (similar to: https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/1097)