### PR TITLE
qemu-libvirt: add variant flatcar with version 1.1.0, to avoid the ct provider to error out

### DIFF
--- a/qemu-libvirt/cl/machine-mynode.yaml.tmpl
+++ b/qemu-libvirt/cl/machine-mynode.yaml.tmpl
@@ -1,4 +1,6 @@
 ---
+variant: flatcar
+version: 1.1.0
 passwd:
   users:
     - name: core

--- a/qemu-libvirt/cl/machine-mynode.yaml.tmpl
+++ b/qemu-libvirt/cl/machine-mynode.yaml.tmpl
@@ -8,7 +8,6 @@ passwd:
 storage:
   files:
     - path: /home/core/works
-      filesystem: root
       mode: 0755
       contents:
         inline: |

--- a/qemu-libvirt/libvirt-machines.tf
+++ b/qemu-libvirt/libvirt-machines.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     libvirt = {
       source  = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "~> 0.7.0"
     }
     ct = {
       source  = "poseidon/ct"

--- a/qemu-libvirt/libvirt-machines.tf
+++ b/qemu-libvirt/libvirt-machines.tf
@@ -7,7 +7,7 @@ terraform {
     }
     ct = {
       source  = "poseidon/ct"
-      version = "0.7.1"
+      version = "~> 0.13.0"
     }
     template = {
       source  = "hashicorp/template"


### PR DESCRIPTION
# small fix to ignition for qemu-libvirt

Add `variant` and `version`, otherwise the `ct` provider errors out:

```
│ Error: error parsing variant; must be specified
│ 
│   with data.ct_config.vm-ignitions["mynode"],
│   on 15_ignition.tf line 1, in data "ct_config" "vm-ignitions":
│    1: data "ct_config" "vm-ignitions" {

```

Tested with:
```bash
$ tofu providers -v
OpenTofu v1.6.2
on linux_amd64
+ provider registry.opentofu.org/dmacvicar/libvirt v0.7.6
+ provider registry.opentofu.org/hashicorp/template v2.2.0
+ provider registry.opentofu.org/poseidon/ct v0.13.0

```