### PR TITLE
make libvirt graphics configurable

### DIFF
--- a/qemu-libvirt/libvirt-machines.tf
+++ b/qemu-libvirt/libvirt-machines.tf
@@ -63,6 +63,7 @@ resource "libvirt_domain" "machine" {
   }
 
   graphics {
+    type        = var.graphics_type
     listen_type = "address"
   }
 

--- a/qemu-libvirt/variables.tf
+++ b/qemu-libvirt/variables.tf
@@ -29,3 +29,9 @@ variable "virtual_cpus" {
   default     = 1
   description = "Number of virtual CPUs"
 }
+
+variable "graphics_type" {
+  type        = string
+  default     = "spice"
+  description = "Graphics type to use (spice or vnc)"
+}


### PR DESCRIPTION
# make libvirt graphics configurable

On my machine I need to set the `graphics` type for libvirt to `vnc`, as `spice` (which is the default) is not usable.

This PR makes this configurable by the user, while keeping the default of `spice`.